### PR TITLE
Fixes "jpg" to ".jpg" and downloads error

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -59,32 +59,28 @@ class FileUtils {
           return Environment.getExternalStorageDirectory() + "/" + split[1];
         }
       } else if (isDownloadsDocument(uri)) {
-                Log.e("message: ", "Downloads External Document URI");
-                final String id = DocumentsContract.getDocumentId(uri);
-
-                if (!TextUtils.isEmpty(id)) {
-                    if (id.startsWith("raw:")) {
-                        return id.replaceFirst("raw:", "");
-                    }
-
-                    String[] contentUriPrefixesToTry = new String[]{
-                            "content://downloads/public_downloads",
-                            "content://downloads/my_downloads",
-                            "content://downloads/all_downloads"
-                    };
-                    for (String contentUriPrefix : contentUriPrefixesToTry) {
-                        Uri contentUri = ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.valueOf(id));
-                        try {
-                            String path = getDataColumn(context, contentUri, null, null);
-                            if (path != null) {
-                                return path;
-                            }
-                        } catch (Exception e) {
-                            Log.e("message: ", "Something went wrong while retrieving document path: " + e.toString());
-                        }
-                    }
-
+          final String id = DocumentsContract.getDocumentId(uri);
+          if (!TextUtils.isEmpty(id)) {
+            if (id.startsWith("raw:")) {
+              return id.replaceFirst("raw:", "");
+            }
+            String[] contentUriPrefixesToTry = new String[]{
+              "content://downloads/public_downloads",
+              "content://downloads/my_downloads",
+              "content://downloads/all_downloads"
+            };
+            for (String contentUriPrefix : contentUriPrefixesToTry) {
+              Uri contentUri = ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.valueOf(id));
+              try {
+                String path = getDataColumn(context, contentUri, null, null);
+                if (path != null) {
+                  return path;
                 }
+              } catch (Exception e) {
+                return null;
+              }
+            }
+          }
       } else if (isMediaDocument(uri)) {
         final String docId = DocumentsContract.getDocumentId(uri);
         final String[] split = docId.split(":");


### PR DESCRIPTION
- Fixed "jpg" to ".jpg" in getPathFromRemoteUri() method
- Fixed downloads error by providing multiple multiple content URI prefixes
- Improved indentation